### PR TITLE
Fixed incorrect Question_Types values for Answers 

### DIFF
--- a/DDL.sql
+++ b/DDL.sql
@@ -155,25 +155,25 @@ VALUES (
 (
     NULL,
     "When the input size is unknown",
-    4,
+    3,
     0
 ),
 (
     NULL,
     "When the input is nearly sorted",
-    4,
+    3,
     0
 ),
 (
     NULL,
     "When additional memory usage is a critical factor",
-    4,
+    3,
     0
 ),
 (
     NULL,
     "When the input size is small",
-    4,
+    3,
     1
 );
 


### PR DESCRIPTION
I noticed that Answers that were meant to have Question_Type 3 were accidentally labeled with Question_Type 4